### PR TITLE
support ruby-2.1 or later.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-09-01  Hiroshi Fujishima  <hirobo@tonteki.org>
+
+	* filters/abbrev-convert.rb, filters/abbrev-simplify-keys.rb:
+	* filters/annotation-filter.rb, filters/asayaKe.rb:
+	* filters/complete-numerative.rb, filters/conjugation.rb:
+	* filters/make-tankan-dic.rb, filters/skkdictools.rb: Support ruby-2.1.
+
 2015-01-16  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* READMEs/FAQ.txt, READMEs/README.C, READMEs/README.skkdic-diff:

--- a/filters/abbrev-simplify-keys.rb
+++ b/filters/abbrev-simplify-keys.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby -Ke
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
 ## Copyright (C) 2005 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -52,6 +52,7 @@ rescue OptionParser::InvalidOption => e
 end
 
 while gets
+  $_ = $_.encode("utf-8", "euc-jis-2004")
   next if $_ =~ /^[^a-zA-Z0-9]/
   tmp = $_.chop.split(" /", 2)
   midasi = tmp.shift.downcase.delete('^a-z0-9')

--- a/filters/annotation-filter.rb
+++ b/filters/annotation-filter.rb
@@ -1,5 +1,5 @@
-#!/usr/local/bin/ruby -Ke
-# -*- coding: euc-jp -*-
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
+# -*- coding: utf-8 -*-
 ## Copyright (C) 2005 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -39,11 +39,11 @@ unannotate_cap = 99999999
 doublebar = "remove"
 rulesets = Array.new
 default_rulesets = [
-  [ "exclude", '¢¨|\?$' ],
-  # [ "exclude", "\[ÈÜ\]" ],
-  [ "keep", 'µì»ú|°ÛÂÎ»ú|ËÜ»ú|Âç»ú|¢÷|¢ª' ],
-  # [ "keep", "NB:|=|¢â|¡â|ÏÂÀ½|<rare>" ],
-  # [ "cut", "¡Â" ] - 'doublebar' handles it inplace
+  [ "exclude", 'â€»|\?$' ],
+  # [ "exclude", "\[å‘\]" ],
+  [ "keep", 'æ—§å­—|ç•°ä½“å­—|æœ¬å­—|å¤§å­—|â€ |â†’' ],
+  # [ "keep", "NB:|=|â‰’|â‰ |å’Œè£½|<rare>" ],
+  # [ "cut", "â€–" ] - 'doublebar' handles it inplace
 ]
 
 
@@ -59,9 +59,9 @@ opt.on('-k', 'keep annotations by default') { keep_annotation = true }
 opt.on('-t', "extraction mode: output requested pairs only") { output_all = false }
 opt.on('-d', "apply default rulesets") { rulesets += default_rulesets }
 
-opt.on('-b', "sticky '¡Â' -- annotation after '¡Â' will always be kept") { doublebar = "sticky" }
-#opt.on('-B', "always remove annotations after '¡Â'") { doublebar = "remove" }
-opt.on('-B', "treat '¡Â' as a part of annotation") { doublebar = "dumb" }
+opt.on('-b', "sticky 'â€–' -- annotation after 'â€–' will always be kept") { doublebar = "sticky" }
+#opt.on('-B', "always remove annotations after 'â€–'") { doublebar = "remove" }
+opt.on('-B', "treat 'â€–' as a part of annotation") { doublebar = "dumb" }
 
 
 begin
@@ -74,13 +74,14 @@ end
 
 
 while gets
+  $_ = $_.encode("utf-8", "euc-jis-2004")
   next if $_ =~ /^;/ || $_ =~ /^$/
   midasi, tokens = $_.parse_skk_entry
-  total = tokens.nitems
+  total = tokens.count {|item| !item.nil? }
   #results = Array.new
 
   tokens.each do |token|
-    word, annotation, comment = token.skk_split_tokens( doublebar == "dumb" ? nil : '¡Â')
+    word, annotation, comment = token.skk_split_tokens( doublebar == "dumb" ? nil : 'â€–')
 
     do_unannotate = !keep_annotation
     do_output = output_all

--- a/filters/asayaKe.rb
+++ b/filters/asayaKe.rb
@@ -1,5 +1,5 @@
-#!/usr/local/bin/ruby -Ke
-# -*- coding: euc-jp -*-
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
+# -*- coding: utf-8 -*-
 ## Copyright (C) 2005 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -28,20 +28,20 @@
 ##
 ### Instruction:
 ## This script converts okuri-nasi pairs with okuri into okuri-ari:
-## ¡Ö¤¢¤µ¤ä¤± /Ä«¾Æ¤±/¡× ¢ª ¡Ö¤¢¤µ¤äk /Ä«¾Æ/¡×
+## ã€Œã‚ã•ã‚„ã‘ /æœç„¼ã‘/ã€ â†’ ã€Œã‚ã•ã‚„k /æœç„¼/ã€
 ##
 ## '-e' simply extracts such pairs.
 ## '-E' outputs both in original and converted forms.
 ##
 ## '-o' given, the okuri is appended as an annotation:
-## ¡Ö¤¢¤µ¤äk /Ä«¾Æ;¡Â-¤±/¡×
+## ã€Œã‚ã•ã‚„k /æœç„¼;â€–-ã‘/ã€
 ##
 ## '-O' given, the result will be in skk-henkan-okuri-strictly format:
-## ¡Ö¤¢¤µ¤äk /Ä«¾Æ/[¤±/Ä«¾Æ]/¡×
+## ã€Œã‚ã•ã‚„k /æœç„¼/[ã‘/æœç„¼]/ã€
 ##
 ## '-u' eliminates all the annotations.
 ##
-## '-p' eliminates pairs with "¢¨" or "?" annotations that are suspected
+## '-p' eliminates pairs with "â€»" or "?" annotations that are suspected
 ## as 'wrong' words.
 ##
 ## NOTE: skkdictools.rb should be in one of the ruby loadpaths.
@@ -65,7 +65,7 @@ opt.on('-E', 'extract and then convert okuri-nasi-with-okuri pairs') { mode = "b
 #opt.on('-f', 'output original pairs if conversion failed') { filter = true }
 opt.on('-o', 'append original "okurigana" as annotation') { okuri_mode = "annotation" }
 opt.on('-O', 'append original "okurigana" in skk-henkan-okuri-strictly format') { okuri_mode = "bracket" }
-opt.on('-p', 'purge candidates marked with "¢¨" or "?"') { purge = true }
+opt.on('-p', 'purge candidates marked with "â€»" or "?"') { purge = true }
 opt.on('-u', 'eliminate annotations') { unannotate = true }
 #opt.on('-s VAL', 'stem candidates equal or shorter than VAL letters') { |v| stem = v.to_i * 2 }
 
@@ -78,6 +78,7 @@ end
 
 
 while gets
+  $_ = $_.encode("utf-8", "euc-jis-2004")
   next if $_ =~ /^;/
   tmp = $_.chop.split(" /", 2)
   midasi = tmp.shift
@@ -86,7 +87,7 @@ while gets
   tokens.each do |token|
     candidate, annotation = token.split(";", 2)
     #next if tmp[0].length <= stem
-    next if purge && annotation =~ /¢¨/
+    next if purge && annotation =~ /â€»/
     next if purge && annotation =~ /\?$/
 
     key, prefix, postfix = okuri_nasi_to_ari(midasi, candidate)
@@ -105,9 +106,9 @@ while gets
 	case okuri_mode
 	when "annotation"
 	  if !unannotate && !annotation.nil?
-	    print ";#{annotation}¡Â-#{postfix}"
+	    print ";#{annotation}â€–-#{postfix}"
 	  else
-	    print ";¡Â-#{postfix}"
+	    print ";â€–-#{postfix}"
 	  end
 	when "bracket"
 	  if !unannotate && !annotation.nil?

--- a/filters/complete-numerative.rb
+++ b/filters/complete-numerative.rb
@@ -1,5 +1,5 @@
-#!/usr/local/bin/ruby -Ke
-# -*- coding: euc-jp -*-
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
+# -*- coding: utf-8 -*-
 ## Copyright (C) 2005 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -26,8 +26,8 @@
 ### Instruction:
 ##
 ## This script is aimed to supplement missing numerative pairs by
-## generating, for example, °÷#§ﬁ§§ /#3ÀÁ/#1ÀÁ/#0ÀÁ/#2ÀÁ/°◊ from
-## °÷#§ﬁ§§ /#0ÀÁ/°◊.
+## generating, for example, „Äå#„Åæ„ÅÑ /#3Êûö/#1Êûö/#0Êûö/#2Êûö/„Äç from
+## „Äå#„Åæ„ÅÑ /#0Êûö/„Äç.
 ##
 ##     % complete-numerative.rb SKK-JISYO.L > SKK-JISYO.num
 ##     % skkdic-expr2 SKK-JISYO.L + SKK-JISYO.num > SKK-JISYO.L.new
@@ -64,7 +64,7 @@ mode = "convert"
 opt.on('-o ORDER', 'specify order of results, eg. "3102" => "/#3/#1/#0/#2/"') { |v| order = v } # TODO - check sanity
 #opt.on('-u', "don't add annotations for derived pairs") { annotation_mode = "self" }
 opt.on('-U', 'eliminate all the annotations') { annotation_mode = "none" }
-opt.on('-p', 'skip candidates marked with "¢®" or "?"') { purge = true }
+opt.on('-p', 'skip candidates marked with "‚Äª" or "?"') { purge = true }
 opt.on('-e', 'only extract numerative entries') { mode = "extract" }
 
 begin
@@ -75,10 +75,11 @@ rescue OptionParser::InvalidOption => e
 end
 
 while gets
+  $_ = $_.encode("utf-8", "euc-jis-2004")
   next if $_ =~ /^;/ || $_ =~ /^$/ || $_ !~ /^[^ ]*#/
   if mode == "extract"
     # XXX This is lazy -- there's a slim chance of extracting
-    # non-numerative pairs such as °÷# /°Ù/°◊
+    # non-numerative pairs such as „Äå# /ÔºÉ/„Äç
     # Anyway it's equivalent to doing grep '^[^ ;]*#'
     print $_
     next
@@ -88,7 +89,7 @@ while gets
   tokens.each do |token|
     word, annotation, comment = token.skk_split_tokens
     next if word !~ /#[0-3]/
-    next if purge && annotation =~ /¢®/
+    next if purge && annotation =~ /‚Äª/
     next if purge && annotation =~ /\?$/
     order.each_byte do |num|
       if annotation_mode == "none"

--- a/filters/conjugation.rb
+++ b/filters/conjugation.rb
@@ -1,5 +1,5 @@
-#!/usr/local/bin/ruby -Ke
-# -*- coding: euc-jp -*-
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
+# -*- coding: utf-8 -*-
 ## Copyright (C) 2005 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -31,35 +31,35 @@
 ## words given, using annotations designed for this purpose
 ## (esp. in SKK-JISYO.notes).
 ##
-##     ¡Ö¤¢¤¤¤·¤¢u /°¦¤·¹ç;¡Â¥ï¹Ô¸ÞÃÊ[wiueot(c)]/¡×
+##     ã€Œã‚ã„ã—ã‚u /æ„›ã—åˆ;â€–ãƒ¯è¡Œäº”æ®µ[wiueot(c)]/ã€
 ##
 ## This pair is expanded into:
 ##
-##     ¡Ö¤¢¤¤¤·¤¢w /°¦¤·¹ç/¡×
-##     ¡Ö¤¢¤¤¤·¤¢i /°¦¤·¹ç/¡×
-##     ¡Ö¤¢¤¤¤·¤¢u /°¦¤·¹ç/¡×
-##     ¡Ö¤¢¤¤¤·¤¢e /°¦¤·¹ç/¡×
-##     ¡Ö¤¢¤¤¤·¤¢o /°¦¤·¹ç/¡×
-##     ¡Ö¤¢¤¤¤·¤¢t /°¦¤·¹ç/¡×
-##     ¡Ö¤¢¤¤¤·¤¢c /°¦¤·¹ç/¡× (if -p option is given)
+##     ã€Œã‚ã„ã—ã‚w /æ„›ã—åˆ/ã€
+##     ã€Œã‚ã„ã—ã‚i /æ„›ã—åˆ/ã€
+##     ã€Œã‚ã„ã—ã‚u /æ„›ã—åˆ/ã€
+##     ã€Œã‚ã„ã—ã‚e /æ„›ã—åˆ/ã€
+##     ã€Œã‚ã„ã—ã‚o /æ„›ã—åˆ/ã€
+##     ã€Œã‚ã„ã—ã‚t /æ„›ã—åˆ/ã€
+##     ã€Œã‚ã„ã—ã‚c /æ„›ã—åˆ/ã€ (if -p option is given)
 ##
 ## By default, okuri-nasi pairs with one-letter 'candidate' will be expanded
 ## in the same manner, eg.:
 ##
-##     ¡Ö¤¢¤¤ /°¦;¡Â¥µÊÑÌ¾»ì[¦Õs]/¡×
+##     ã€Œã‚ã„ /æ„›;â€–ã‚µå¤‰åè©ž[Ï†s]/ã€
 ##
-##     ¡Ö¤¢¤¤ /°¦/¡×
-##     ¡Ö¤¢¤¤s /°¦/¡×
+##     ã€Œã‚ã„ /æ„›/ã€
+##     ã€Œã‚ã„s /æ„›/ã€
 ##
 ## while -O suppress this kind of expansion, -o option allows it for
 ## candidates of any length:
 ##
-##     ¡Ö¤·¤ó¤³¤¯ /¿¼¹ï;¡Â·ÁÍÆÆ°»ì[¦Õdns]/¡×
+##     ã€Œã—ã‚“ã“ã /æ·±åˆ»;â€–å½¢å®¹å‹•è©ž[Ï†dns]/ã€
 ##
-##     ¡Ö¤·¤ó¤³¤¯ /¿¼¹ï/¡×
-##     ¡Ö¤·¤ó¤³¤¯d /¿¼¹ï/¡×
-##     ¡Ö¤·¤ó¤³¤¯n /¿¼¹ï/¡×
-##     ¡Ö¤·¤ó¤³¤¯s /¿¼¹ï/¡×
+##     ã€Œã—ã‚“ã“ã /æ·±åˆ»/ã€
+##     ã€Œã—ã‚“ã“ãd /æ·±åˆ»/ã€
+##     ã€Œã—ã‚“ã“ãn /æ·±åˆ»/ã€
+##     ã€Œã—ã‚“ã“ãs /æ·±åˆ»/ã€
 ##     
 ##
 ## NOTE: skkdictools.rb should be in the loadpath of ruby.
@@ -77,51 +77,51 @@ okuri_nasi_too = "oneletter"
 #okuri_strictly_output = false
 purge = false
 
-# ¸«¤¢¤²¤ë¡¢¸«¤Ð¤¨¡¢¸«¤Á¤ã¤Ã¤¿¡¢¸«¤É¤³¤í¡¢¸«¤¨¤Ê¤¤¡¢¸«¤Ï¤é¤·¡¢¸«¤´¤¿¤¨¡¢
-# ¸«¤¤¤À¤¹¡¢¸«¤¸¡¢¸«¤«¤Í¤ë¡¢¸«¤Þ¤¹¡¢¸«¤Ê¤¤¡¢¸«¤ª¤í¤¹¡¢¸«¤Ã¤Ñ¤Ê¤·¡¢¸«¤ë¡¢
-# ¸«¤»¤ë¡¢¸«¤Æ¡¢¸«¤¦¤·¤Ê¤¦¡¢¸«¤ï¤±¤ë¡¢¸«¤è¤¦¡¢¸«¤º¡£
-# ([flqvx]) - x can be useful, however it doesn't work well (¡Ö¸«¤£¤Ê¡×)
+# è¦‹ã‚ã’ã‚‹ã€è¦‹ã°ãˆã€è¦‹ã¡ã‚ƒã£ãŸã€è¦‹ã©ã“ã‚ã€è¦‹ãˆãªã„ã€è¦‹ã¯ã‚‰ã—ã€è¦‹ã”ãŸãˆã€
+# è¦‹ã„ã ã™ã€è¦‹ã˜ã€è¦‹ã‹ã­ã‚‹ã€è¦‹ã¾ã™ã€è¦‹ãªã„ã€è¦‹ãŠã‚ã™ã€è¦‹ã£ã±ãªã—ã€è¦‹ã‚‹ã€
+# è¦‹ã›ã‚‹ã€è¦‹ã¦ã€è¦‹ã†ã—ãªã†ã€è¦‹ã‚ã‘ã‚‹ã€è¦‹ã‚ˆã†ã€è¦‹ãšã€‚
+# ([flqvx]) - x can be useful, however it doesn't work well (ã€Œè¦‹ãƒãªã€)
 all_strings = "abcdeghijkmnoprstuwyz"
 
-# #¤Ë¤ó /#3¿Í/#1¿Í/#0¿Í/#2¿Í/
+# #ã«ã‚“ /#3äºº/#1äºº/#0äºº/#2äºº/
 numerative_order = [3, 1, 0, 2]
 
-# ¥«ÊÑ (¤¯r /Íè/)
-# ¥µÊÑ (¤¹r /°Ù/)
-# ¥¢¹Ô²¼Æó (¤¢¤ê¤¦r /Í­¤êÆÀ/)
+# ã‚«å¤‰ (ãr /æ¥/)
+# ã‚µå¤‰ (ã™r /ç‚º/)
+# ã‚¢è¡Œä¸‹äºŒ (ã‚ã‚Šã†r /æœ‰ã‚Šå¾—/)
 IrregularConjugationTable = [
-  [ "¥«ÊÑ", "¤¯r",
+  [ "ã‚«å¤‰", "ãr",
     [
-      # (¤¯) Íè¤ë, Íè¤ó¤Ê (,¤¯¤Ã¤¾, ¤¯¤Ã¤«¤Ê (, ¤¯¤Ã¤Ù))
-      "¤¯r", "¤¯n", # "¤¯z", "¤¯k", "¤¯b",
-      # (¤³) Íè¤¤, Íè¤Ê¤¤, Íè¤é¤ì¤ë, Íè¤µ¤»¤ë, Íè¤è¤¦, Íè¤º
-      "¤³i", "¤³n", "¤³r", "¤³s", "¤³y", "¤³z",
-      # (¤­) Íè¤Á¤ã¤¦, Íè¤Å¤é¤¤, Íè¤Þ¤¹, Íè¤Ê, Íè¤½¤¦, Íè¤Æ, Íè¤ä¤¬¤Ã¤¿,
-      "¤­c", "¤­d", "¤­m", "¤­n", "¤­s", "¤­t", "¤­y",
-      # (¤­¤¨¤Ê¤¤, ¤­¤Ï¤·¤Ê¤¤¡¦¤­¤Ï¤ë, ¤­¤¤¤Ê, ¤­¤Ã¤³¤Ê¤¤, ¤­¤ª¤ë)
-      #"¤­e", "¤­h", "¤­i", "¤­k", "¤­o",
+      # (ã) æ¥ã‚‹, æ¥ã‚“ãª (,ãã£ãž, ãã£ã‹ãª (, ãã£ã¹))
+      "ãr", "ãn", # "ãz", "ãk", "ãb",
+      # (ã“) æ¥ã„, æ¥ãªã„, æ¥ã‚‰ã‚Œã‚‹, æ¥ã•ã›ã‚‹, æ¥ã‚ˆã†, æ¥ãš
+      "ã“i", "ã“n", "ã“r", "ã“s", "ã“y", "ã“z",
+      # (ã) æ¥ã¡ã‚ƒã†, æ¥ã¥ã‚‰ã„, æ¥ã¾ã™, æ¥ãª, æ¥ãã†, æ¥ã¦, æ¥ã‚„ãŒã£ãŸ,
+      "ãc", "ãd", "ãm", "ãn", "ãs", "ãt", "ãy",
+      # (ããˆãªã„, ãã¯ã—ãªã„ãƒ»ãã¯ã‚‹, ãã„ãª, ãã£ã“ãªã„, ããŠã‚‹)
+      #"ãe", "ãh", "ãi", "ãk", "ão",
     ]],
 
-  [ "¥µÊÑ", "¤¹r",
+  [ "ã‚µå¤‰", "ã™r",
     [
-      # (¤¹) °Ù¤ë, °Ù¤Þ¤¤ (,¤¹¤ó¤Ê, ¤¹¤Ã¤¾, ¤¹¤Ã¤«¤Ê)
-      "¤¹r", "¤¹m", #"¤¹n", "¤¹z", "¤¹k",
-      # (¤·) °Ù¤Á¤ã¤¨, °Ù¤Þ¤¹, °Ù¤Ê¤¤, °Ù¤í, °Ù¤½¤¦, °Ù¤Æ, °Ù¤è¤¦
-      "¤·c", "¤·m", "¤·n", "¤·r", "¤·s", "¤·t", "¤·y",
-      # (,¤·¤Ã¤³¤Ê¤¤, ¤·¤¦¤ë, ¤·¤Å¤é¤¤)
-      #"¤·k", "¤·u", "¤·d",
-      # (¤») °Ù¤è, °Ù¤º (,¤»¤¤, ¤»¤Ð)
-      "¤»y", "¤»z", #"¤»i", "¤»b"
+      # (ã™) ç‚ºã‚‹, ç‚ºã¾ã„ (,ã™ã‚“ãª, ã™ã£ãž, ã™ã£ã‹ãª)
+      "ã™r", "ã™m", #"ã™n", "ã™z", "ã™k",
+      # (ã—) ç‚ºã¡ã‚ƒãˆ, ç‚ºã¾ã™, ç‚ºãªã„, ç‚ºã‚, ç‚ºãã†, ç‚ºã¦, ç‚ºã‚ˆã†
+      "ã—c", "ã—m", "ã—n", "ã—r", "ã—s", "ã—t", "ã—y",
+      # (,ã—ã£ã“ãªã„, ã—ã†ã‚‹, ã—ã¥ã‚‰ã„)
+      #"ã—k", "ã—u", "ã—d",
+      # (ã›) ç‚ºã‚ˆ, ç‚ºãš (,ã›ã„, ã›ã°)
+      "ã›y", "ã›z", #"ã›i", "ã›b"
     ]],
 
-  [ "¥¢¹Ô²¼Æó", "¤¦r",
+  [ "ã‚¢è¡Œä¸‹äºŒ", "ã†r",
     [
-      # (¤¦) Í­¤êÆÀ¤Ù¤·, Í­¤êÆÀ¤ë
-      "¤¦b", "¤¦r",
-      # (¤¨) ÆÀ¤Á¤ã¤¦, ÆÀ¤Þ¤¹, ÆÀ¤Ê¤¤, ÆÀ¤ë, ÆÀ¤½¤¦, ÆÀ¤Æ, ÆÀ¤è¤¦, ÆÀ¤º
-      "¤¨c", "¤¨m", "¤¨n", "¤¨r", "¤¨s", "¤¨t", "¤¨y", "¤¨z"
-      # (,¤¨¤Ã¤«¤Ê, ¤¨¤¸, ¤¨¤Ç(¤«))
-      #"¤¨k", "¤¨j", "¤¨d",
+      # (ã†) æœ‰ã‚Šå¾—ã¹ã—, æœ‰ã‚Šå¾—ã‚‹
+      "ã†b", "ã†r",
+      # (ãˆ) å¾—ã¡ã‚ƒã†, å¾—ã¾ã™, å¾—ãªã„, å¾—ã‚‹, å¾—ãã†, å¾—ã¦, å¾—ã‚ˆã†, å¾—ãš
+      "ãˆc", "ãˆm", "ãˆn", "ãˆr", "ãˆs", "ãˆt", "ãˆy", "ãˆz"
+      # (,ãˆã£ã‹ãª, ãˆã˜, ãˆã§(ã‹))
+      #"ãˆk", "ãˆj", "ãˆd",
     ]]
 ]
 
@@ -139,7 +139,7 @@ opt.on('-C', 'eliminate all the comments') { $comment_mode = "discard" }
 opt.on('-p', "use OKURIs in parentheses too") { parentheses = "use" }
 opt.on('-o', "process okuri-nasi pairs too (eg. SAHEN verbs and adjective verbs)") { okuri_nasi_too = "all" }
 opt.on('-O', "never process okuri-nasi pairs") { okuri_nasi_too = "none" }
-opt.on('-x', 'skip candidates marked with "¢¨" or "?"') { purge = true }
+opt.on('-x', 'skip candidates marked with "â€»" or "?"') { purge = true }
 
 begin
   opt.parse!(ARGV)
@@ -149,11 +149,12 @@ rescue OptionParser::InvalidOption => e
 end
 
 while gets
+  $_ = $_.encode("utf-8", "euc-jis-2004")
   next if $_ =~ /^;/ || $_ =~ /^$/
   midasi, tokens = $_.parse_skk_entry
   next if tokens.nil?
 
-  if (/^(>?[¤¡-¤ó¡«¡¼]*)([a-z]+)$/ =~ midasi)
+  if (/^(>?[ã-ã‚“ã‚›ãƒ¼]*)([a-z]+)$/ =~ midasi)
     stem = $1
     okuri = $2
   elsif okuri_nasi_too == "none"
@@ -169,10 +170,10 @@ while gets
     next if tmp[1].nil?
     word = tmp[0]
     next if okuri.empty? && okuri_nasi_too == "oneletter" && word.length > 2
-    annotation, comment = tmp[1].split("¡Â", 2)
+    annotation, comment = tmp[1].split("â€–", 2)
     next if comment.nil?
-    next if purge && annotation =~ /¢¨|\?$/
-    comment.sub!(/¢ù.*$/, '')
+    next if purge && annotation =~ /â€»|\?$/
+    comment.sub!(/Â¶.*$/, '')
 
     new_index = 0
     while index = (comment[new_index .. -1] =~ /\[([^\]]*)\]/)
@@ -185,7 +186,7 @@ while gets
 	derivation.gsub!(/[()]/, '')
       end
 
-      # XXX what if ¡Ö¤¢u /¹ç;¡ÂÊä½õÆ°»ì[<wiueot(c)]/¡×?
+      # XXX what if ã€Œã‚u /åˆ;â€–è£œåŠ©å‹•è©ž[<wiueot(c)]/ã€?
       suffix = derivation.gsub!(/</, '')
       numerative = derivation.gsub!(/#/, '')
 
@@ -209,7 +210,7 @@ while gets
 	next
       end
 
-      if derivation.gsub!(/¦Õ/, '')
+      if derivation.gsub!(/Ï†/, '')
 	print_pair2(stem, word, annotation, comment, (okuri == ""))
       end
 

--- a/filters/make-tankan-dic.rb
+++ b/filters/make-tankan-dic.rb
@@ -1,5 +1,5 @@
-#!/usr/local/bin/ruby -Ke
-# -*- coding: euc-jp -*-
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
+# -*- coding: utf-8 -*-
 ## Copyright (C) 2006 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -51,7 +51,7 @@ max_size = 2
 
 
 opt.on('-u', 'remove annotations') { keep_annotation = false }
-opt.on('-p', 'purge candidates marked with "¢®" or "?"') { purge = true }
+opt.on('-p', 'purge candidates marked with "‚Äª" or "?"') { purge = true }
 opt.on('-m VAL', 'minimal size of each word (in byte)') { |i| min_size = i.to_i }
 opt.on('-M VAL', 'maximal size of each word (in byte)') { |i| max_size = i.to_i }
 
@@ -64,14 +64,15 @@ end
 
 
 while gets
-  next if $_ =~ /^;/ || $_ =~ /^$/ || $_ !~ /^[§°-§Û]/
+  $_ = $_.encode("utf-8", "euc-jis-2004")
+  next if $_ =~ /^;/ || $_ =~ /^$/ || $_ !~ /^[„ÅÅ-„Çì]/
   midasi, tokens = $_.parse_skk_entry
 
   notyet = true
   tokens.each do |token|
     word, annotation, comment = token.skk_split_tokens
     next if word.size < min_size || word.size > max_size
-    next if purge && annotation =~ /¢®/
+    next if purge && annotation =~ /‚Äª/
     next if purge && annotation =~ /\?$/
     # TODO: check if it's `Kanji'
     if notyet

--- a/filters/skkdictools.rb
+++ b/filters/skkdictools.rb
@@ -1,5 +1,5 @@
-#!/usr/local/bin/ruby -Ke
-# -*- coding: euc-jp -*-
+#!/usr/bin/env ruby -E euc-jis-2004:utf-8
+# -*- coding: utf-8 -*-
 ## Copyright (C) 2005 MITA Yuusuke <clefs@mail.goo.ne.jp>
 ##
 ## Author: MITA Yuusuke <clefs@mail.goo.ne.jp>
@@ -44,38 +44,38 @@
 #require 'timeout'
 
 # exceptions:
-#	["¤Á" , "c"] (eg. ¡Ö¤Ë¤¤¤Á¤ã¤ó /·»¤Á¤ã¤ó/¡×¢ª¡Ö¤Ë¤¤c /·»/¡×)
-#	["¤Ã" , "p"] (eg. ¡Ö¤Ä¤Ã¤Ñ¤ë /ÆÍ¤Ã¤Ñ¤ë/¡×¢ª¡Ö¤Äp /ÆÍ/¡×)
-#	["¤Ã" , "c"] (eg. ¡Ö¤µ¤­¤Ã¤Á¤ç /Àè¤Ã¤Á¤ç/¡×¢ª¡Ö¤µ¤­c /Àè/¡×)
+#	["ã¡" , "c"] (eg. ã€Œã«ã„ã¡ã‚ƒã‚“ /å…„ã¡ã‚ƒã‚“/ã€â†’ã€Œã«ã„c /å…„/ã€)
+#	["ã£" , "p"] (eg. ã€Œã¤ã£ã±ã‚‹ /çªã£ã±ã‚‹/ã€â†’ã€Œã¤p /çª/ã€)
+#	["ã£" , "c"] (eg. ã€Œã•ãã£ã¡ã‚‡ /å…ˆã£ã¡ã‚‡/ã€â†’ã€Œã•ãc /å…ˆ/ã€)
 GyakuhikiOkurigana = [
-  ["¤¢" , "a"],
-  ["¤Ğ" , "b"], ["¤Ó" , "b"], ["¤Ö" , "b"], ["¤Ù" , "b"], ["¤Ü" , "b"],
-  ["¤À" , "d"], ["¤Â" , "d"], ["¤Å" , "d"], ["¤Ç" , "d"], ["¤É" , "d"],
-  ["¤¨" , "e"],
-  ["¤¬" , "g"], ["¤®" , "g"], ["¤°" , "g"], ["¤²" , "g"], ["¤´" , "g"],
-  ["¤Ï" , "h"], ["¤Ò" , "h"], ["¤Õ" , "h"], ["¤Ø" , "h"], ["¤Û" , "h"],
-  ["¤¤" , "i"],
-  ["¤¸" , "j"],
-  ["¤«" , "k"], ["¤­" , "k"], ["¤¯" , "k"], ["¤±" , "k"], ["¤³" , "k"],
-  ["¤Ş" , "m"], ["¤ß" , "m"], ["¤à" , "m"], ["¤á" , "m"], ["¤â" , "m"],
-  ["¤Ê" , "n"], ["¤Ë" , "n"], ["¤Ì" , "n"], ["¤Í" , "n"], ["¤Î" , "n"], ["¤ó" , "n"],
-  ["¤ª" , "o"],
-  ["¤Ñ" , "p"], ["¤Ô" , "p"], ["¤×" , "p"], ["¤Ú" , "p"], ["¤İ" , "p"],
-  ["¤é" , "r"], ["¤ê" , "r"], ["¤ë" , "r"], ["¤ì" , "r"], ["¤í" , "r"],
-  ["¤µ" , "s"], ["¤·" , "s"], ["¤¹" , "s"], ["¤»" , "s"], ["¤½" , "s"],
-  ["¤¿" , "t"], ["¤Á" , "t"], ["¤Ã" , "t"], ["¤Ä" , "t"], ["¤Æ" , "t"], ["¤È" , "t"],
-  ["¤¦" , "u"],
-  ["¤ï" , "w"], ["¤ò" , "w"],
-  ["¤¡" , "x"], ["¤£" , "x"], ["¤¥" , "x"], ["¤§" , "x"], ["¤©" , "x"],
-  ["¤ã" , "x"], ["¤å" , "x"], ["¤ç" , "x"], ["¤î" , "x"], ["¤ğ" , "x"], ["¤ñ" , "x"],
-  ["¤ã" , "y"], ["¤ä" , "y"], ["¤å" , "y"], ["¤æ" , "y"], ["¤ç" , "y"], ["¤è" , "y"],
-  ["¤¶" , "z"], ["¤¸" , "z"], ["¤º" , "z"], ["¤¼" , "z"], ["¤¾" , "z"]
+  ["ã‚" , "a"],
+  ["ã°" , "b"], ["ã³" , "b"], ["ã¶" , "b"], ["ã¹" , "b"], ["ã¼" , "b"],
+  ["ã " , "d"], ["ã¢" , "d"], ["ã¥" , "d"], ["ã§" , "d"], ["ã©" , "d"],
+  ["ãˆ" , "e"],
+  ["ãŒ" , "g"], ["ã" , "g"], ["ã" , "g"], ["ã’" , "g"], ["ã”" , "g"],
+  ["ã¯" , "h"], ["ã²" , "h"], ["ãµ" , "h"], ["ã¸" , "h"], ["ã»" , "h"],
+  ["ã„" , "i"],
+  ["ã˜" , "j"],
+  ["ã‹" , "k"], ["ã" , "k"], ["ã" , "k"], ["ã‘" , "k"], ["ã“" , "k"],
+  ["ã¾" , "m"], ["ã¿" , "m"], ["ã‚€" , "m"], ["ã‚" , "m"], ["ã‚‚" , "m"],
+  ["ãª" , "n"], ["ã«" , "n"], ["ã¬" , "n"], ["ã­" , "n"], ["ã®" , "n"], ["ã‚“" , "n"],
+  ["ãŠ" , "o"],
+  ["ã±" , "p"], ["ã´" , "p"], ["ã·" , "p"], ["ãº" , "p"], ["ã½" , "p"],
+  ["ã‚‰" , "r"], ["ã‚Š" , "r"], ["ã‚‹" , "r"], ["ã‚Œ" , "r"], ["ã‚" , "r"],
+  ["ã•" , "s"], ["ã—" , "s"], ["ã™" , "s"], ["ã›" , "s"], ["ã" , "s"],
+  ["ãŸ" , "t"], ["ã¡" , "t"], ["ã£" , "t"], ["ã¤" , "t"], ["ã¦" , "t"], ["ã¨" , "t"],
+  ["ã†" , "u"],
+  ["ã‚" , "w"], ["ã‚’" , "w"],
+  ["ã" , "x"], ["ãƒ" , "x"], ["ã…" , "x"], ["ã‡" , "x"], ["ã‰" , "x"],
+  ["ã‚ƒ" , "x"], ["ã‚…" , "x"], ["ã‚‡" , "x"], ["ã‚" , "x"], ["ã‚" , "x"], ["ã‚‘" , "x"],
+  ["ã‚ƒ" , "y"], ["ã‚„" , "y"], ["ã‚…" , "y"], ["ã‚†" , "y"], ["ã‚‡" , "y"], ["ã‚ˆ" , "y"],
+  ["ã–" , "z"], ["ã˜" , "z"], ["ãš" , "z"], ["ãœ" , "z"], ["ã" , "z"]
 ]
 
-# ("¤¢¤µ¤ä¤±", "Ä«¾Æ¤±") => ("¤¢¤µ¤äk", "Ä«¾Æ", "¤±")
-# ("¤Í¤³", "Ç­") => nil
+# ("ã‚ã•ã‚„ã‘", "æœç„¼ã‘") => ("ã‚ã•ã‚„k", "æœç„¼", "ã‘")
+# ("ã­ã“", "çŒ«") => nil
 def okuri_nasi_to_ari(midasi, candidate)
-  return nil if (/(.*[^¤¡-¤ó¡¼])([¤¡-¤ó]+)$/ !~ candidate)
+  return nil if (/(.*[^ã-ã‚“ãƒ¼])([ã-ã‚“]+)$/ !~ candidate)
   can_prefix = $1
   can_postfix = $2
   return nil if !(can_prefix && can_postfix && (/(.+)#{can_postfix}$/ =~ midasi))
@@ -87,9 +87,9 @@ def okuri_nasi_to_ari(midasi, candidate)
   # handle some exceptions
   # XXX inplace of changing "t" into "c", this function should return
   # both "t" and "c"
-  okuri = "c" if can_postfix =~ /^¤Ã¤Á/ || can_postfix =~ /^¤Á[¤ã¤å¤ç]/
-  okuri = "p" if can_postfix =~ /^¤Ã[¤Ñ-¤İ]/
-  okuri = "k" if can_postfix =~ /^¤Ã[¤«-¤³]/
+  okuri = "c" if can_postfix =~ /^ã£ã¡/ || can_postfix =~ /^ã¡[ã‚ƒã‚…ã‚‡]/
+  okuri = "p" if can_postfix =~ /^ã£[ã±-ã½]/
+  okuri = "k" if can_postfix =~ /^ã£[ã‹-ã“]/
 
   return key_prefix + okuri, can_prefix, can_postfix
 end
@@ -99,13 +99,13 @@ def print_pair(key, candidate, annotation = nil, comment = nil)
     if comment.nil? || comment.empty?
       print "#{key} /#{candidate};#{annotation}/\n"
     else
-      print "#{key} /#{candidate};#{annotation}¡Â#{comment}/\n"
+      print "#{key} /#{candidate};#{annotation}â€–#{comment}/\n"
     end
   else
     if comment.nil? || comment.empty?
       print "#{key} /#{candidate}/\n"
     else
-      print "#{key} /#{candidate};¡Â#{comment}/\n"
+      print "#{key} /#{candidate};â€–#{comment}/\n"
     end
   end
 end
@@ -113,18 +113,18 @@ end
 # borrowed from skkform.rb
 class String
   def to_katakana
-    self.gsub(/¤¦¡«/, '\\1¥ô').tr('¤¡-¤ó', '¥¡-¥ó')
+    self.gsub(/ã†ã‚›/, '\\1ãƒ´').tr('ã-ã‚“', 'ã‚¡-ãƒ³')
   end
 
   def to_hiragana
-    self.gsub(/¥ô/, '¤¦¡«').tr('¥¡-¥ó', '¤¡-¤ó')
+    self.gsub(/ãƒ´/, 'ã†ã‚›').tr('ã‚¡-ãƒ³', 'ã-ã‚“')
   end
 
   def cut_off_prefix_postfix
-    self.sub(/^[<>\?]([¡¼¤¡-¤ó]+)$/, '\1').sub(/^([¡¼¤¡-¤ó]+)[<>\?]$/, '\1')
+    self.sub(/^[<>\?]([ãƒ¼ã-ã‚“]+)$/, '\1').sub(/^([ãƒ¼ã-ã‚“]+)[<>\?]$/, '\1')
   end
 
-  # from ¡Ö¥ª¥Ö¥¸¥§¥¯¥È»Ø¸ş¥¹¥¯¥ê¥×¥È¸À¸ìruby¡×p121
+  # from ã€Œã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆæŒ‡å‘ã‚¹ã‚¯ãƒªãƒ—ãƒˆè¨€èªrubyã€p121
   def csv_split(delimiter = ',')
     csv = []
     data = ""
@@ -177,7 +177,7 @@ class String
     return midasi, tokens
   end
 
-  def skk_split_tokens(delimiter = '¡Â')
+  def skk_split_tokens(delimiter = 'â€–')
     word, annotation = self.split(";", 2)
     return word, nil, nil if annotation.nil?
     return word, annotation, nil if delimiter.nil?
@@ -198,12 +198,12 @@ class Goo
 	sock.printf("GET /web.jsp?DC=1&MT=\"%s\" HTTP/1.0\r\n\r\n", key)
 	sock.readlines.each do |line|
 	  line = Kconv.toeuc(line)
-	  if (/<b>Ìó*([,0-9]+)<\/b>·ïÃæ/ =~ line)
+	  if (/<b>ç´„*([,0-9]+)<\/b>ä»¶ä¸­/ =~ line)
 	    hits = $1.gsub(/,/, '').to_i
 	    return hits if hits > 0
 	  # 0hits, or system error?
-	  elsif (/<br>³ºÅö¤¹¤ë¸¡º÷·ë²Ì¤¬¸«Åö¤¿¤ê¤Ş¤»¤ó¡£/ =~ line)
-	  #elsif (/<br>¸¡º÷¥·¥¹¥Æ¥à¤«¤é¸¡º÷·ë²Ì¤òÀµ¾ï¤Ë¼èÆÀ¤Ç¤­¤Ê¤«¤Ã¤¿²ÄÇ½À­¤¬¤¢¤ê¤Ş¤¹¡£/ =~ line) next
+	  elsif (/<br>è©²å½“ã™ã‚‹æ¤œç´¢çµæœãŒè¦‹å½“ãŸã‚Šã¾ã›ã‚“ã€‚/ =~ line)
+	  #elsif (/<br>æ¤œç´¢ã‚·ã‚¹ãƒ†ãƒ ã‹ã‚‰æ¤œç´¢çµæœã‚’æ­£å¸¸ã«å–å¾—ã§ããªã‹ã£ãŸå¯èƒ½æ€§ãŒã‚ã‚Šã¾ã™ã€‚/ =~ line) next
 	    return 0
 	  end
 	end


### PR DESCRIPTION
ruby-2.1 以降で動くようにしました。

http://ref.xaio.jp/ruby/classes/array/nitems を参考に単純に nitems を count {|item| !item.nil? } に置き換えただけでは、
```
% sed -n 16108p SKK-JISYO.notes | ruby-1.8.7 -I ~/skktools/filters ~/skktools/filters/conjugation.rb -Cpox
ていぞう /逓増;次第に増えること/
ていぞうs /逓増;次第に増えること/
% sed -n 16108p SKK-JISYO.notes | ruby-2.2.3 -I ~/skktools/filters ~/skktools/filters/conjugation.rb -Cpox
ていぞう /逓増;第に増えること/
ていぞうs /逓増;第に増えること/
```
となってしまうのですが、ファイルのエンコーディングを UTF-8 にしたところ、1.8 と同等な出力になったため、
ファイルのエンコーディングも変更しました。

また、abbrev-convert.rb の -s オプションが ruby 1.9 以降で string.length の挙動がバイト数から文字数に変更されたことにより、うまく動作していなかった点も修正しました。

euc-jis-2004 を使用しているため、ruby-2.0 以前では動かないです。
(ruby-2.0 の場合 euc-jis-2004 を euc-jp-2004 に変更することで動くと思います)
euc-jp では、SKK-JISYO.L+ を annotation-filter.rb で処理するときにエラーになりました。