### PR TITLE
バ行五段活用撥音便の追加および数接続の分解

### DIFF
--- a/convert2skk/ipadic2skk.rb
+++ b/convert2skk/ipadic2skk.rb
@@ -104,7 +104,7 @@ while gets
   end
 
   tail = ""
-  if key =~ /^\{(.*)\}([ぁ-ん]*)$/
+  if key =~ /^\{(.*)\}([ぁ-ん#]*)$/
     tail = $2
     # (読み {チネツ/ジネツ})
     keys = $1.split("/")
@@ -127,6 +127,7 @@ while gets
           comment_extra += "[wiueot(c)]" if postfix == "う" && conjugation =~ /ワ行五段/
           comment_extra += "[gi]" if postfix == "ぐ" && conjugation =~ /ガ行五段/
           comment_extra += "[mn]" if postfix == "む" && conjugation =~ /マ行五段/
+          comment_extra += "[bn]" if postfix == "ぶ" && conjugation =~ /バ行五段/
           comment_extra += "[*]" if postfix == "る" && conjugation =~ /カ変/
           comment_extra += "[rt(cn)]" if postfix == "る" && conjugation =~ /ラ行五段/
           # this can be of problem


### PR DESCRIPTION
NAIST Japanese Dictionary 0.4.3 を変換するときに問題となる箇所を修正しました。
変更点は以下の2点です。バ行五段活用撥音便についてはIPA辞書にも共通していると思います。

1. バ行五段活用の撥音便を追加します。

* naist-jdic
> (品詞 (動詞 自立)) ((見出し語 (遊ぶ 2264)) (読み アソブ) (発音 アソブ) (活用型 五段・バ行) )

* 変更前の出力
> あそb /遊;∥動詞 自立 バ行五段 (-ぶ)/

* 変更後の出力
> あそb /遊;∥動詞 自立 バ行五段 \[bn\](-ぶ)/

conjugation.rbを通すと、以下の出力を得ることができるようになります。
> あそb /遊/
> あそn /遊/

2. 複数の読みを持つ数接続を分解します。

* naist-jdic
> (品詞 (接頭詞 数接続)) ((見出し語 (小 1925)) (読み {ショウ/コ}) (発音 {ショー/コ}) )

* 変更前の出力
> {しょう/こ}# /小#0;∥接頭詞 数接続/

* 変更後の出力
> しょう# /小#0;∥接頭詞 数接続/
> こ# /小#0;∥接頭詞 数接続/

よろしくお願いします。