### PR TITLE
Fix skkdic-expr2 segfaults when unmatched bracket is in candidates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-01-26  Tatsuya Kinoshita  <tats@debian.org>
+
+	* skkdic-expr2.c (splitCandidates): Prevent buffer overflow read
+	when "/[" is found and "]" is not found in the candidates.
+
 2020-03-14  Tsuyoshi Kitamoto  <tsuyoshi.kitamoto@gmail.com>
 
 	* convert2skk/edict2toskk.el: Add new file.

--- a/skkdic-expr2.c
+++ b/skkdic-expr2.c
@@ -262,6 +262,7 @@ static GSList *splitCandidates(gchar *str)
 			if(*q < 0x20) break;
 			if(*q == '[') {
 				while(*q != ']') {
+					if(*q == '\0') break;
 					q++;
 				}
 				p = q;


### PR DESCRIPTION
* skkdic-expr2.c (splitCandidates): Prevent buffer overflow read
when "/[" is found and "]" is not found in the candidates.

This patch fixes that `make SKK-JISYO.emoji VER=38.1` in skk-dev/dict
causes segfault with the candidate `/[;U+5b/`.

```
$ make SKK-JISYO.emoji VER=38.1
...
emacs --batch --directory ./ --load emoji.el --funcall kanjionly | skkdic-expr2 > SKK-JISYO.emoji.kanji
...
Segmentation fault
make: *** [Makefile:196: SKK-JISYO.emoji.kanji] Error 139

$ echo '大括弧 /[;U+5b/' | skkdic-expr2
Segmentation fault
```

Note that the format "/[...]/" is for skk-henkan-okuri-strictly.
cf. skk-dev/skktools/READMEs/FAQ.md, skk-dev/dict/committers.md

P.S. The variable name "VER" is too short.  It would be better to
use "CLDR_VER", "UNICODE_CLDR_VER" or so.
