### PR TITLE
Make skk2cdb.py compatible to Python 3

### DIFF
--- a/skk2cdb.py
+++ b/skk2cdb.py
@@ -31,14 +31,14 @@ if pack('=i',1) == pack('>i',1):
     return a
   def encode(a):
     a.byteswap()
-    return str(a)
+    return a
 else:
   # little endian
   def decode(x):
     a = array('I', x)
     return a
   def encode(a):
-    return str(a)
+    return a
 
 
 ##  CDB
@@ -205,7 +205,7 @@ class CDBMaker:
           i = (i+2) % len(a)
         a[i] = h
         a[i+1] = p
-      self._fp.write(encode(a).encode())
+      self._fp.write(encode(a))
     # write header
     self._fp.seek(0)
     a = array('I')
@@ -213,7 +213,7 @@ class CDBMaker:
       a.append(pos_hash)
       a.append(len(b1))
       pos_hash += len(b1)*8
-    self._fp.write(encode(a).encode())
+    self._fp.write(encode(a))
     # close
     self._fp.close()
     os.rename(self.fntmp, self.fn)

--- a/skk2cdb.py
+++ b/skk2cdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##
 ##  skk2cdb.py - convertion tool for SKK dictionary.
 ##  by Yusuke Shinyama
@@ -16,11 +16,12 @@
 import sys, os
 from struct import pack, unpack
 from array import array
+from functools import reduce
 
 
 # calc hash value with a given key
-def cdbhash(s, n=0L):
-  return reduce(lambda h,c: ((h*33) ^ ord(c)) & 0xffffffffL, s, n+5381L)
+def cdbhash(s, n=0):
+  return reduce(lambda h,c: ((h*33) ^ ord(c)) & 0xffffffff, s, n+5381)
 
 if pack('=i',1) == pack('>i',1):
   # big endian
@@ -64,7 +65,7 @@ class CDBReader:
     self.name = cdbname
     self._fp = file(cdbname, 'rb')
     hash0 = decode(self._fp.read(2048))
-    self._hash0 = [ (hash0[i], hash0[i+1]) for i in xrange(0, 512, 2) ]
+    self._hash0 = [ (hash0[i], hash0[i+1]) for i in range(0, 512, 2) ]
     self._hash1 = [ None ] * 256
     (self._eod,_) = self._hash0[0]
     self._docache = docache
@@ -93,7 +94,7 @@ class CDBReader:
       self._hash1[h1] = hs
     i = ((h >> 8) % ncells) * 2
     n = ncells*2
-    for _ in xrange(ncells):
+    for _ in range(ncells):
       p1 = hs[i+1]
       if p1 == 0: raise KeyError(k)
       if hs[i] == h:
@@ -122,7 +123,7 @@ class CDBReader:
       return False
 
   def __contains__(self, k):
-    return self.has_key(k)
+    return k in self
 
   def firstkey(self):
     self._keyiter = None
@@ -132,7 +133,7 @@ class CDBReader:
     if not self._keyiter:
       self._keyiter = ( k for (k,v) in cdbiter(self._fp, self._eod) )
     try:
-      return self._keyiter.next()
+      return next(self._keyiter)
     except StopIteration:
       return None
 
@@ -140,7 +141,7 @@ class CDBReader:
     if not self._eachiter:
       self._eachiter = cdbiter(self._fp, self._eod)
     try:
-      return self._eachiter.next()
+      return next(self._eachiter)
     except StopIteration:
       return None
   
@@ -161,7 +162,7 @@ class CDBMaker:
     self.numentries = 0
     self._fp = file(tmpname, 'wb')
     self._pos = 2048                    # sizeof((h,p))*256
-    self._bucket = [ array('I') for _ in xrange(256) ]
+    self._bucket = [ array('I') for _ in range(256) ]
     return
 
   def __len__(self):
@@ -197,7 +198,7 @@ class CDBMaker:
       if not b1: continue
       blen = len(b1)
       a = array('I', [0]*blen*2)
-      for j in xrange(0, blen, 2):
+      for j in range(0, blen, 2):
         (h,p) = (b1[j],b1[j+1])
         i = ((h >> 8) % blen)*2
         while a[i+1]:             # is cell[i] already occupied?
@@ -248,7 +249,7 @@ def cdbmerge(iters):
   q = []
   for it in iters:
     try:
-      q.append((it.next(),it))
+      q.append((next(it),it))
     except StopIteration:
       pass
   k0 = None
@@ -262,7 +263,7 @@ def cdbmerge(iters):
     vs.append(v)
     k0 = k
     try:
-      q.append((it.next(),it))
+      q.append((next(it),it))
     except StopIteration:
       continue
   if vs: yield (k0,vs)
@@ -280,7 +281,7 @@ def main(argv):
   import fileinput
   import os.path
   def usage():
-    print 'usage: %s [-f] outfile [infile ...]' % argv[0]
+    print('usage: %s [-f] outfile [infile ...]' % argv[0])
     return 100
   try:
     (opts, args) = getopt.getopt(argv[1:], 'dfo:')
@@ -292,7 +293,7 @@ def main(argv):
   if not args: return usage()
   outfile = args.pop(0)
   if not force and os.path.exists(outfile):
-    print >>sys.stderr, 'file exists: %r' % outfile
+    print('file exists: %r' % outfile, file=sys.stderr)
     return 1
   #
   maker = CDBMaker(outfile, outfile+'.tmp')

--- a/skk2cdb.py
+++ b/skk2cdb.py
@@ -175,12 +175,12 @@ class CDBMaker:
     raise TypeError
 
   def add(self, k, v):
-    (k, v) = (str(k), str(v))
+    (k, v) = (k.decode('iso-8859-1'), v.decode('iso-8859-1'))
     (klen, vlen) = (len(k), len(v))
     self._fp.seek(self._pos)
     self._fp.write(pack('<II', klen, vlen))
-    self._fp.write(k.encode())
-    self._fp.write(v.encode())
+    self._fp.write(k.encode('iso-8859-1'))
+    self._fp.write(v.encode('iso-8859-1'))
     h = cdbhash(k)
     b = self._bucket[h % 256]
     b.append(h)
@@ -297,11 +297,11 @@ def main(argv):
     return 1
   #
   maker = CDBMaker(outfile, outfile+'.tmp')
-  for line in fileinput.input(args, openhook=fileinput.hook_encoded('euc-jp')):
+  for line in fileinput.input(args, mode='rb'):
     line = line.strip()
-    if line.startswith(';'): continue
+    if line.startswith(b';'): continue
     try:
-      i = line.index(' ')
+      i = line.index(b' ')
     except ValueError:
       continue
     (k,v) = (line[:i], line[i+1:])


### PR DESCRIPTION
I've updated skk2cdb.py to work with Python 3 based on <https://github.com/skk-dev/skktools/pull/20>.

As a workaround, I use iso-8859-1 to avoid utf-8 convertion and
manage euc-jp/euc-jis-2004 strings as binary strings.  Though I'm
not familiar with Python 3, it works now anyway.
