### PR TITLE
libdb が必要であることを README に記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ $ make
 $ make install
 ```
 
-ビルドには gdbm-devel パッケージ (GNU database indexing library) が必要です。
+ビルドには libdb-devel パッケージ (Berkeley DB library) が必要です。
 
 ```
-$ dnf install gdbm-devel
+$ dnf install libdb-devel
+```
+```
+$ sudo apt install libdb-dev
 ```
 
 他のディレクトリについては、必要に応じてそれぞれのディレクトリを参照してください。


### PR DESCRIPTION
https://github.com/skk-dev/skktools/issues/8#issuecomment-218156739

libdb-dev を入れれば、CPPFLAGS も変更せずにビルドが通るみたいです
```
gcc -I. -I. -I. -g -O2 -o skkdic-expr ./skkdic-expr.c -ldb
gcc -I. -I. -I. -g -O2 -o skkdic-sort ./skkdic-sort.c
gcc -I. -I. -I. -g -O2 -o skkdic-count ./skkdic-count.c
gcc -I. -I. -I. -g -O2 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -o skkdic-expr2 ./skkdic-expr2.c -lglib-2.0
```

gdbm を使う環境もあるのであれば README に残すべきでしょうけど
私の環境では gdbm 系のパッケージをぜんぶ入れてもビルドできませんでした
