### PR TITLE
Avoid function prototype empty arguments to fix gcc-15 build

### DIFF
--- a/skkdic-expr.c
+++ b/skkdic-expr.c
@@ -112,8 +112,8 @@ int snprintf(char *s, size_t maxlen, const char *format, ...)
 /* 送りがながついたエントリを含めて処理を行わせるかどうか */
 int	okurigana_flag;
 
-static int add_content_line();
-static void subtract_content_line();
+static int add_content_line(unsigned char *, unsigned char *, datum *);
+static void subtract_content_line(unsigned char *, unsigned char *, datum *);
 
 /* Part1: 辞書データベース基本操作プログラム */
 


### PR DESCRIPTION
# Summary
Some functions have prototypes with empty argument list but they actually receives a parameters.
Such code is allowed until C17/18, but gcc-15 makes them errors.
This patch fixes the prototypes to have expected parameter type list to suppress the error.

# Environment
* Gentoo Linux (x86-64)
* gcc 15.1.1 (`sys-devel/gcc-15.1.1_p20250614` of Gentoo repository)

# Relevant part of the build log

<details>
<summary>build log (`emerge =app-i18n/skktools-1.3.4-r1` on Gentoo)</summary>

```
>>> Compiling source in /var/tmp/portage/app-i18n/skktools-1.3.4-r1/work/skktools-1.3.4 ...
make -j32
x86_64-pc-linux-gnu-gcc -I. -I. -I. -march=native -O2 -pipe -o skkdic-expr ./skkdic-expr.c -lgdbm_compat   -lgdbm -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs
x86_64-pc-linux-gnu-gcc -I. -I. -I. -march=native -O2 -pipe -o skkdic-sort ./skkdic-sort.c -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs
x86_64-pc-linux-gnu-gcc -I. -I. -I. -march=native -O2 -pipe -o skkdic-count ./skkdic-count.c -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs
x86_64-pc-linux-gnu-gcc -I. -I. -I. -march=native -O2 -pipe -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -o skkdic-expr2 ./skkdic-expr2.c -lglib-2.0 -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs
./skkdic-count.c: In function ‘count_entry’:
./skkdic-count.c:39:1: warning: old-style function definition [-Wold-style-definition]
   39 | count_entry(filename, fp)
      | ^~~~~~~~~~~
./skkdic-count.c: In function ‘main’:
./skkdic-count.c:68:5: warning: old-style function definition [-Wold-style-definition]
   68 | int main(argc, argv)
      |     ^~~~
./skkdic-sort.c: In function ‘hexcomp’:
./skkdic-sort.c:106:1: warning: old-style function definition [-Wold-style-definition]
  106 | hexcomp(a, b)
      | ^~~~~~~
./skkdic-sort.c: In function ‘okuriari’:
./skkdic-sort.c:118:12: warning: old-style function definition [-Wold-style-definition]
  118 | static int okuriari(p)
      |            ^~~~~~~~
./skkdic-sort.c: In function ‘skkcompar’:
./skkdic-sort.c:132:5: warning: old-style function definition [-Wold-style-definition]
  132 | int skkcompar(a, b)
      |     ^~~~~~~~~
./skkdic-sort.c: In function ‘main’:
./skkdic-sort.c:180:5: warning: old-style function definition [-Wold-style-definition]
  180 | int main(argc, argv)
      |     ^~~~
./skkdic-expr.c: In function ‘db_remove_file’:
./skkdic-expr.c:122:13: warning: old-style function definition [-Wold-style-definition]
  122 | static void db_remove_file(fname)
      |             ^~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘db_append’:
./skkdic-expr.c:193:13: warning: old-style function definition [-Wold-style-definition]
  193 | static void db_append(key, new, dbm)
      |             ^~~~~~~~~
./skkdic-expr.c: In function ‘getpos’:
./skkdic-expr.c:210:13: warning: old-style function definition [-Wold-style-definition]
  210 | static long getpos(ptr)
      |             ^~~~~~
./skkdic-expr.c: In function ‘db_replace’:
./skkdic-expr.c:224:13: warning: old-style function definition [-Wold-style-definition]
  224 | static void db_replace(ptr, new)
      |             ^~~~~~~~~~
./skkdic-expr.c: In function ‘db_gets’:
./skkdic-expr.c:233:13: warning: old-style function definition [-Wold-style-definition]
  233 | static void db_gets(ptr, len, fp)
      |             ^~~~~~~
./skkdic-expr.c: In function ‘signal_handler’:
./skkdic-expr.c:244:1: warning: old-style function definition [-Wold-style-definition]
  244 | signal_handler (signo)
      | ^~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘match_item’:
./skkdic-expr.c:282:12: warning: old-style function definition [-Wold-style-definition]
  282 | static int match_item(base, s, e)
      |            ^~~~~~~~~~
./skkdic-expr.c: In function ‘append_item’:
./skkdic-expr.c:301:13: warning: old-style function definition [-Wold-style-definition]
  301 | static void append_item(base, s, e)
      |             ^~~~~~~~~~~
./skkdic-expr.c: In function ‘add_okuri_item’:
./skkdic-expr.c:317:6: warning: old-style function definition [-Wold-style-definition]
  317 | void add_okuri_item(key, s)
      |      ^~~~~~~~~~~~~~
./skkdic-expr.c:359:13: error: too many arguments to function ‘add_content_line’; expected 0, have 3
  359 |         if (add_content_line(new, content, NULL))
      |             ^~~~~~~~~~~~~~~~ ~~~
./skkdic-expr.c:115:12: note: declared here
  115 | static int add_content_line();
      |            ^~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘add_okuri_tail_line’:
./skkdic-expr.c:367:12: warning: old-style function definition [-Wold-style-definition]
  367 | static int add_okuri_tail_line(tails, line)
      |            ^~~~~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘add_content_line’:
./skkdic-expr.c:397:12: warning: old-style function definition [-Wold-style-definition]
  397 | static int add_content_line(base, new, key)
      |            ^~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘item_number’:
./skkdic-expr.c:433:12: warning: old-style function definition [-Wold-style-definition]
  433 | static int item_number(p)
      |            ^~~~~~~~~~~
./skkdic-expr.c: In function ‘line_process’:
./skkdic-expr.c:442:12: warning: old-style function definition [-Wold-style-definition]
  442 | static int line_process(buffer, key, kanji, tails)
      |            ^~~~~~~~~~~~
./skkdic-expr.c:460:5: error: too many arguments to function ‘add_content_line’; expected 0, have 3
  460 |     add_content_line(kanji, buffer+key_len+1, key);
      |     ^~~~~~~~~~~~~~~~ ~~~~~
./skkdic-expr.c:397:12: note: declared here
  397 | static int add_content_line(base, new, key)
      |            ^~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘add_file’:
./skkdic-expr.c:467:13: warning: old-style function definition [-Wold-style-definition]
  467 | static void add_file(srcname)
      |             ^~~~~~~~
./skkdic-expr.c:502:21: error: too many arguments to function ‘add_content_line’; expected 0, have 3
  502 |                 if (add_content_line(new, kanji, NULL))
      |                     ^~~~~~~~~~~~~~~~ ~~~
./skkdic-expr.c:397:12: note: declared here
  397 | static int add_content_line(base, new, key)
      |            ^~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘delete_item’:
./skkdic-expr.c:511:1: warning: old-style function definition [-Wold-style-definition]
  511 | delete_item(base, s, e)
      | ^~~~~~~~~~~
./skkdic-expr.c: In function ‘subtract_okuri_item’:
./skkdic-expr.c:536:6: warning: old-style function definition [-Wold-style-definition]
  536 | void subtract_okuri_item(key, s)
      |      ^~~~~~~~~~~~~~~~~~~
./skkdic-expr.c:576:9: error: too many arguments to function ‘subtract_content_line’; expected 0, have 3
  576 |         subtract_content_line(new, content, NULL);
      |         ^~~~~~~~~~~~~~~~~~~~~ ~~~
./skkdic-expr.c:116:13: note: declared here
  116 | static void subtract_content_line();
      |             ^~~~~~~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘subtract_okuri_tail_line’:
./skkdic-expr.c:586:6: warning: old-style function definition [-Wold-style-definition]
  586 | void subtract_okuri_tail_line(tails, line)
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘subtract_content_line’:
./skkdic-expr.c:610:1: warning: old-style function definition [-Wold-style-definition]
  610 | subtract_content_line(base, new, key)
      | ^~~~~~~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘subtract_file’:
./skkdic-expr.c:641:13: warning: old-style function definition [-Wold-style-definition]
  641 | static void subtract_file(srcname)
      |             ^~~~~~~~~~~~~
./skkdic-expr.c:678:17: error: too many arguments to function ‘subtract_content_line’; expected 0, have 3
  678 |                 subtract_content_line(new, kanji, &key);
      |                 ^~~~~~~~~~~~~~~~~~~~~ ~~~
./skkdic-expr.c:610:1: note: declared here
  610 | subtract_content_line(base, new, key)
      | ^~~~~~~~~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘okuri_type_out’:
./skkdic-expr.c:689:6: warning: old-style function definition [-Wold-style-definition]
  689 | void okuri_type_out(key, output)
      |      ^~~~~~~~~~~~~~
./skkdic-expr.c: In function ‘type_out’:
./skkdic-expr.c:743:13: warning: old-style function definition [-Wold-style-definition]
  743 | static void type_out(output)
      |             ^~~~~~~~
./skkdic-expr.c: In function ‘print_usage’:
./skkdic-expr.c:781:13: warning: old-style function definition [-Wold-style-definition]
  781 | static void print_usage(argc, argv)
      |             ^~~~~~~~~~~
./skkdic-expr.c: In function ‘main’:
./skkdic-expr.c:791:5: warning: old-style function definition [-Wold-style-definition]
  791 | int main(argc, argv)
      |     ^~~~
make: *** [Makefile:66: skkdic-expr] Error 1
make: *** Waiting for unfinished jobs....
```

</details>